### PR TITLE
fix motore di ricerca

### DIFF
--- a/assets/scripts/home_search.js
+++ b/assets/scripts/home_search.js
@@ -20,7 +20,7 @@ var idx = lunr(function () {
     let entry = {
       'metaname': key,
       'title': window.searchschede[key].title,
-      'tema': window.searchschede[key].tema,
+      'description': window.searchschede[key].description,
       'subtitle': window.searchschede[key].subtitle,
       'url': window.searchschede[key].url
     }
@@ -61,6 +61,8 @@ const formSubmit = function() {
   search_for = $('#home-cerca').val();
 
   const results = idx.search('*' + search_for + '*');
+  // const results = idx.search('tema:*' + search_for + '*^100 *' + search_for + '*');
+  console.log(results)
   displayResults(results);
 }
 

--- a/index.html
+++ b/index.html
@@ -84,8 +84,8 @@ scripts:
     {% for scheda in all_schede %}
       "{{ scheda.items[0].object | slugify }}": {
         "title": "{{ scheda.items[0].title | xml_escape }}",
-        "tema": "{{ scheda.items[0].tema | xml_escape }}",
         "subtitle": "{{ scheda.items[0].subtitle | xml_escape }}",
+        "description": "{{ scheda.items[0].description | xml_escape }}",
         "url": "{{ scheda.items[0].url | xml_escape }}",
         "type": "scheda"
       }


### PR DESCRIPTION
- rimossa chiave di ricerca "tema" per togliere risultati inattesi (es. tema "cacciapesca", cercando "caccia" tornavano anche i risultati per "pesca")
- aggiunta chiave di ricerca "descrizione"